### PR TITLE
Release/v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+## [0.2.0] - 2017-08-31
+
+### Changed
+
+* With `recursive: true`, sort keys inside `Array` too [#1](https://github.com/yuya-takeyama/sort_by_key/pull/1)
+
+## [0.1.0] - 2017-06-28
+
+* Initial release

--- a/lib/sort_by_key/version.rb
+++ b/lib/sort_by_key/version.rb
@@ -1,3 +1,3 @@
 module SortByKey
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## [0.2.0] - 2017-08-31

### Changed

* With `recursive: true`, sort keys inside `Array` too [#1](https://github.com/yuya-takeyama/sort_by_key/pull/1)
